### PR TITLE
fix: make sure we have a warm apt cache

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -127,6 +127,7 @@ done
 # See https://github.com/18F/ubuntu/blob/master/hardening.md#password-policy
 ###
 
+apt update
 apt-get upgrade -y libpam-pwquality
 
 cp etc/pam.d/common-password /etc/pam.d/common-password


### PR DESCRIPTION
## Changes proposed in this pull request:
- make sure we have a warm apt cache. the post-deploy currently fails because it can't find packages, but after `apt update` I can see those packages. I assume the old toolbelt release hit apt, and the new one doesn't

## security considerations
This should increase security by ensuring we're installing the latest versions of packages available from Ubuntu